### PR TITLE
 set proper permissions for server.key

### DIFF
--- a/docs_manual/source/admin_install.rst
+++ b/docs_manual/source/admin_install.rst
@@ -117,6 +117,7 @@ certificates can be used for evaluation and testing.
 
     $ cp yourcert.crt config/traefik/tls/server.crt
     $ cp yourcert.key config/traefik/tls/server.key
+    $ chmod +r config/traefik/tls/server.key
 
 iRODS also excepts a ``dhparams.pem`` file for Diffie-Hellman key exchange. You
 can generate the file using OpenSSL as demonstrated below.

--- a/docs_manual/source/dev_install.rst
+++ b/docs_manual/source/dev_install.rst
@@ -97,6 +97,7 @@ Once generated, ensure your ``.crt`` and ``.key`` files are placed under the
 
     $ cp yourcert.crt config/traefik/tls/server.crt
     $ cp yourcert.key config/traefik/tls/server.key
+    $ chmod +r config/traefik/tls/server.key
 
 To generate the ``dhparams.pem`` file for Diffie-Hellman key exchange, you can
 use OpenSSL as demonstrated below. Ensure the file is placed under


### PR DESCRIPTION
Right now server.key is owned by the local user or root and has default permissions of 600. From within Docker iRODS wants to access this file via the internal user irods and fails. This is mostly (only?) noticeable when trying to handshake for a Davrods connection, which results in an internal server error message and this in the irods container:

`ERROR: sslInit: couldn't read key file. SSL error: error:0200100D:system library:fopen:Permission denied`

To resolve this (unless there is an easier way) we should instruct the user to set at least 644 permissions on the server.key file.