### PR TITLE
fix: input widget not accepting multiple files

### DIFF
--- a/samplesheets/forms.py
+++ b/samplesheets/forms.py
@@ -40,12 +40,13 @@ class SheetImportForm(forms.Form):
     directory.
     """
 
+    class MultipleFileInput(forms.ClearableFileInput):
+        allow_multiple_selected = True
+
     file_upload = forms.FileField(
         allow_empty_file=False,
         help_text='Zip archive or ISA-Tab files for a single investigation',
-        widget=forms.ClearableFileInput(
-            attrs={'allow_multiple_selected': True}
-        ),
+        widget=MultipleFileInput(attrs={'multiple': True}),
     )
 
     class Meta:


### PR DESCRIPTION
As per [Django documentation](https://docs.djangoproject.com/en/4.2/topics/http/file-uploads/#uploading-multiple-files) a subclass needs to created to set attribute `allow_multiple_selected=True`. args should remain as `'multiple': True`.

fixes #1670