### PR TITLE
fix handling of empty strings in ISA-tab templates

### DIFF
--- a/samplesheets/forms.py
+++ b/samplesheets/forms.py
@@ -192,13 +192,13 @@ class SheetTemplateCreateForm(forms.Form):
                 self.initial[k] = clean_sheet_dir_name(project.title)
             elif isinstance(v, str):
                 if not v:  # Allow empty value if default is not set
-                    field_kwargs = {'required': False}
+                    field_kwargs['required'] = False
                 self.fields[k] = forms.CharField(**field_kwargs)
                 self.initial[k] = v
             elif isinstance(v, list):
                 field_kwargs['choices'] = [(x, x) for x in v]
                 if not all(v):  # Allow empty value if in options
-                    field_kwargs = {'required': False}
+                    field_kwargs['required'] = False
                 self.fields[k] = forms.ChoiceField(**field_kwargs)
             elif isinstance(v, dict):
                 field_kwargs['widget'] = forms.Textarea(


### PR DESCRIPTION
Handling of empty strings in cookiecutter templates currently overwrites the entire kwargs object when probably only `required=False` should be added.

fixes #1700 

Interesting side note: When this bug was triggered, `django.forms.*Field` was called without a label argument. The resulting view showed the respective label anyway, but with a capital first letter and spaces instead of underscores. Not sure how this happens, but it's actually a nicer looking label.