### PR TITLE
cytof plugin: generate links for data files

### DIFF
--- a/samplesheets/assayapps/cytof/plugins.py
+++ b/samplesheets/assayapps/cytof/plugins.py
@@ -146,12 +146,13 @@ class SampleSheetAssayPlugin(SampleSheetAssayPluginPoint):
                     url=base_url + '/' + mc_assay_name + '/' + row[i]['value'],
                 )
 
-            # Create derived data file links
+            # Create data file links
             elif (
                 header['obj_cls'] == 'GenericMaterial'
                 and header['item_type'] == 'DATA'
                 and header['value'].lower() == 'name'
-                and top_header['value'].lower() == 'derived data file'
+                and top_header['value'].lower()
+                in ['raw data file', 'derived data file']
             ):
                 row[i]['link'] = (
                     base_url + '/' + mc_assay_name + '/' + row[i]['value']

--- a/samplesheets/assayapps/cytof/plugins.py
+++ b/samplesheets/assayapps/cytof/plugins.py
@@ -115,6 +115,7 @@ class SampleSheetAssayPlugin(SampleSheetAssayPluginPoint):
 
         for i in range(len(row)):
             header = table['field_header'][i]
+            top_header = get_top_header(table, i)
 
             # Create barcode key & antibody panel links in processes
             if (
@@ -143,6 +144,17 @@ class SampleSheetAssayPlugin(SampleSheetAssayPluginPoint):
                 row[i]['value'] = SIMPLE_LINK_TEMPLATE.format(
                     label=row[i]['value'],
                     url=base_url + '/' + mc_assay_name + '/' + row[i]['value'],
+                )
+
+            # Create derived data file links
+            elif (
+                header['obj_cls'] == 'GenericMaterial'
+                and header['item_type'] == 'DATA'
+                and header['value'].lower() == 'name'
+                and top_header['value'].lower() == 'derived data file'
+            ):
+                row[i]['link'] = (
+                    base_url + '/' + mc_assay_name + '/' + row[i]['value']
                 )
 
         return row


### PR DESCRIPTION
Mass cytometry experiments usually undergo a data pre-processing step involving de-multiplexing and quality assurance gating. This (potentially) produces a Derived Data File as defined by the ISA standard. 

This PR enables automatic Derived Data File link generation for MC assays. These files are usually generated per measurement run (per Assay Name) so the links should point into the respective data collection.

Edit: These are derived from raw data files of course, so we should probably also enable linking to those.