### PR TITLE
updated documentation to reflect sodar_uuid in verifyzone -z,--zone (#2368)

### DIFF
--- a/docs_manual/source/app_landingzones_transfer.rst
+++ b/docs_manual/source/app_landingzones_transfer.rst
@@ -304,12 +304,13 @@ owner and the project owner group, as well as set its status as ``ACTIVE``,
 making the zone available for further actions.
 
 This can be done from the zone dropdown in the SODAR UI under
-:guilabel:`Reset Zone`. Alternatively, the following management command can be
-used:
+:guilabel:`Reset Zone`. Alternatively, the command-line option "-z", expects a
+LandingZone.sodar_uuid as its value:
 
 .. code-block:: bash
 
-    $ ./manage.py resetzone -z {ZONE_UUID}
+    $ ./manage.py resetzone -z {SODAR_UUID}
+
 
 As these actions require administrator access, you should contact the admins of
 your SODAR instance to request a reset.


### PR DESCRIPTION
(https://github.com/bihealth/sodar-server/issues/2368)
Updated documentation for argument -z or --zone for the resetzone  command expecting LandingZone.sodar_uuid as its value, specified in the argument help text. 