### PR TITLE
Upgrade tooz to v9.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -113,7 +113,7 @@ cubi-isa-templates==0.1.2
 # -e git+https://github.com/bihealth/cubi-isa-templates.git@d3ebe866f3823d81fdb358042ef7ed4d8b8fd100#egg=cubi-isa-templates
 
 # Taskflow requirements
-tooz==7.0.0
+tooz==9.0.1
 taskflow==6.3.0
 
 # DRF-spectacular for OpenAPI schema generation

--- a/taskflowbackend/api.py
+++ b/taskflowbackend/api.py
@@ -258,7 +258,7 @@ class TaskflowAPI:
             if not coordinator:
                 cls._raise_lock_exception(COORDINATOR_EX_MSG, tl_event, zone)
             else:
-                lock_id = str(project.sodar_uuid).encode()
+                lock_id = str(project.sodar_uuid)
                 lock = coordinator.get_lock(lock_id)
                 try:
                     lock_api.acquire(lock)
@@ -392,6 +392,6 @@ class TaskflowAPI:
         """
         # NOTE: We query redis directly to allow having to call acquire()
         # NOTE: Yes, this is how tooz encodes the lock IDs (see #2144)
-        lock_db_id = f"b'_tooz'_{project.sodar_uuid}_lock".encode()
+        lock_db_id = f'_tooz_{project.sodar_uuid}_lock'.encode()
         redis_conn = redis.from_url(settings.REDIS_URL, decode_responses=True)
         return redis_conn.get(lock_db_id) is not None

--- a/taskflowbackend/api.py
+++ b/taskflowbackend/api.py
@@ -258,7 +258,7 @@ class TaskflowAPI:
             if not coordinator:
                 cls._raise_lock_exception(COORDINATOR_EX_MSG, tl_event, zone)
             else:
-                lock_id = str(project.sodar_uuid)
+                lock_id = str(project.sodar_uuid).encode()
                 lock = coordinator.get_lock(lock_id)
                 try:
                     lock_api.acquire(lock)

--- a/taskflowbackend/lock_api.py
+++ b/taskflowbackend/lock_api.py
@@ -35,7 +35,7 @@ class ProjectLockAPI:
         msg = '{} {} for project {}'.format(
             'Unlock' if unlock else 'Lock',
             'FAILED' if failed else 'OK',
-            lock.name.split('_')[2],
+            str(lock.name).split('_')[2],
         )
         logger.error(msg) if failed else logger.info(msg)
 


### PR DESCRIPTION
This PR addresses #2485. After upgrading, the lock name is returned as a `bytes` object, which made `_log_status()` fail. It seems that the internal encoding of the lock id has also changed: I checked by printing the keys in redis and I didn't see `"b'_tooz'_{project.sodar_uuid}_lock"` but rather `'_tooz_{project.sodar_uuid}_lock'`.